### PR TITLE
Advertise skills in ~/.claude/CLAUDE.md (gstack-style)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# my-skills — CLAUDE.md block
+
+The `setup` script manages a marker-delimited block inside
+`~/.claude/CLAUDE.md`. The block tells Claude which `my-skills` are installed
+and how to install/update them. It's regenerated on every `./setup` run so
+newly added skills show up automatically.
+
+The installed block looks like this:
+
+```
+<!-- BEGIN my-skills -->
+Available my-skills skills:
+
+/ideation
+/roadmap
+
+Install with: git clone https://github.com/hiboute/my-skills.git ~/.claude/skills/my-skills && ~/.claude/skills/my-skills/setup
+Update with:  ~/.claude/skills/my-skills/bin/my-skills-upgrade
+<!-- END my-skills -->
+```
+
+To remove the block, run `./setup --uninstall`.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ git clone https://github.com/hiboute/my-skills.git ~/.claude/skills/my-skills
 1. Creates symlinks `~/.claude/skills/<skill>` → `~/.claude/skills/my-skills/<skill>`
    for every skill folder in this repo.
 2. Marks scripts in `bin/` executable.
-3. Installs a `SessionStart` hook in `~/.claude/settings.json` that silently checks
-   for new versions on each Claude Code session start.
+3. Installs a `SessionStart` hook in `~/.claude/settings.json` that, on each
+   Claude Code session start, forks a background job which `git pull`s the repo,
+   re-runs `setup -q` if `HEAD` moved, and logs to
+   `~/.my-skills/analytics/session-update.log`. Pattern modeled on gstack's
+   `gstack-session-update`: exits fast, never blocks the session, 1h throttle,
+   lockfile with stale-PID detection.
 4. Writes a marker-delimited block to `~/.claude/CLAUDE.md` listing the installed
    skills and the install/update commands, so Claude knows they exist. The block
    is regenerated on every run; any content outside the `<!-- BEGIN/END my-skills -->`
@@ -34,32 +38,46 @@ newly added skills.
 
 ## Update
 
-The `SessionStart` hook runs `bin/my-skills-update-check` quietly in the background.
-It compares the local `VERSION` file against the remote one on `main` and writes a
-marker to `~/.my-skills/just-upgraded-from` when there's something newer.
+Updates happen automatically on the next Claude Code session start (forked to
+the background — zero latency). The `SessionStart` hook runs
+`bin/my-skills-session-update`, which:
 
-To actually pull updates:
+- Exits 0 immediately (fork to background; never blocks session startup)
+- Throttles to at most one check per hour
+- Acquires a lockfile (with stale-PID detection) to avoid concurrent upgrades
+- Runs `git pull --ff-only` and, if `HEAD` moved, re-runs `./setup -q`
+- Writes `~/.my-skills/just-upgraded-from` so the next session can surface a note
+- Logs every run to `~/.my-skills/analytics/session-update.log`
+
+To force an update now (outside of a session):
 
 ```bash
 ~/.claude/skills/my-skills/bin/my-skills-upgrade
 ```
 
-This runs `git pull --ff-only` and re-runs `setup` to relink any new skills.
+To see whether a newer version is available without pulling:
+
+```bash
+~/.claude/skills/my-skills/bin/my-skills-update-check
+```
 
 ## State directory
 
-Update-check state lives in `~/.my-skills/`:
-- `last-update-check` — epoch of the last remote check (1h cooldown)
-- `update-snoozed` — `<version> <level> <epoch>` snooze record
+State lives in `~/.my-skills/`:
+- `last-session-update` — epoch of the last auto-update run (1h throttle)
+- `last-update-check` — epoch of the last manual version check (1h cooldown)
+- `update-snoozed` — `<version> <level> <epoch>` snooze record (manual check only)
 - `just-upgraded-from` — marker for "you just upgraded from version X"
+- `.setup-lock/` — lockfile directory used during background auto-updates
+- `analytics/session-update.log` — per-run log of the auto-update hook
 
 Delete this dir to fully reset update state.
 
 ## Disable the auto-update hook
 
 Edit `~/.claude/settings.json` and remove the entry whose `command` references
-`my-skills-update-check`. The skills themselves keep working — only the periodic
-check stops.
+`my-skills-session-update`. The skills themselves keep working — only the
+periodic auto-update stops.
 
 ## Uninstall
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,19 @@ git clone https://github.com/hiboute/my-skills.git ~/.claude/skills/my-skills
 ~/.claude/skills/my-skills/setup
 ```
 
-`setup` does three things:
+`setup` does four things:
 1. Creates symlinks `~/.claude/skills/<skill>` → `~/.claude/skills/my-skills/<skill>`
    for every skill folder in this repo.
 2. Marks scripts in `bin/` executable.
 3. Installs a `SessionStart` hook in `~/.claude/settings.json` that silently checks
    for new versions on each Claude Code session start.
+4. Writes a marker-delimited block to `~/.claude/CLAUDE.md` listing the installed
+   skills and the install/update commands, so Claude knows they exist. The block
+   is regenerated on every run; any content outside the `<!-- BEGIN/END my-skills -->`
+   markers is preserved.
 
-Re-run `setup` any time to repair links or pick up newly added skills.
+Re-run `setup` any time to repair links, refresh the CLAUDE.md block, or pick up
+newly added skills.
 
 ## Update
 
@@ -62,8 +67,8 @@ check stops.
 ~/.claude/skills/my-skills/setup --uninstall
 ```
 
-Removes symlinks and the hook entry. Leaves the repo dir and `~/.my-skills/` alone
-in case you want to reinstall.
+Removes symlinks, the hook entry, and the CLAUDE.md block. Leaves the repo dir
+and `~/.my-skills/` alone in case you want to reinstall.
 
 ## License
 

--- a/bin/my-skills-session-update
+++ b/bin/my-skills-session-update
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# my-skills-session-update — auto-update my-skills on session start.
+#
+# Registered as a Claude Code SessionStart hook by ./setup. Must be fast,
+# silent, and non-fatal — the hook exits immediately while the actual
+# update runs in a background fork so session startup is never delayed.
+#
+# Exit 0 always — errors here must never block a Claude Code session.
+#
+# Pattern modeled on gstack's gstack-session-update.
+
+set +e
+
+REPO_DIR="${MY_SKILLS_DIR:-$HOME/.claude/skills/my-skills}"
+STATE_DIR="${MY_SKILLS_STATE_DIR:-$HOME/.my-skills}"
+THROTTLE_FILE="$STATE_DIR/last-session-update"
+LOCK_DIR="$STATE_DIR/.setup-lock"
+LOG_FILE="$STATE_DIR/analytics/session-update.log"
+THROTTLE_SECONDS=3600  # 1 hour
+
+# Drain any hook payload on stdin so the producer doesn't block.
+[ -t 0 ] || cat >/dev/null 2>&1 || true
+
+log_entry() {
+  mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $1" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# ── Guard: my-skills must be a git repo ──
+if [ ! -d "$REPO_DIR/.git" ]; then
+  exit 0
+fi
+
+# ── Throttle: skip if checked recently ──
+if [ -f "$THROTTLE_FILE" ]; then
+  LAST=$(cat "$THROTTLE_FILE" 2>/dev/null || echo 0)
+  NOW=$(date +%s)
+  ELAPSED=$(( NOW - LAST ))
+  if [ "$ELAPSED" -lt "$THROTTLE_SECONDS" ]; then
+    exit 0
+  fi
+fi
+
+# ── Fork to background: zero latency on session start ──
+(
+  # Prevent git from prompting for credentials (would hang the background process)
+  export GIT_TERMINAL_PROMPT=0
+
+  mkdir -p "$STATE_DIR"
+
+  # ── Acquire lockfile (skip if another session is running setup) ──
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    # Lock exists — check if stale (PID dead)
+    if [ -f "$LOCK_DIR/pid" ]; then
+      LOCK_PID=$(cat "$LOCK_DIR/pid" 2>/dev/null || echo 0)
+      if [ "$LOCK_PID" -gt 0 ] 2>/dev/null && ! kill -0 "$LOCK_PID" 2>/dev/null; then
+        rm -rf "$LOCK_DIR" 2>/dev/null
+        mkdir "$LOCK_DIR" 2>/dev/null || { log_entry "SKIP lock_contested"; exit 0; }
+      else
+        log_entry "SKIP locked_by=$LOCK_PID"
+        exit 0
+      fi
+    else
+      log_entry "SKIP locked_no_pid"
+      exit 0
+    fi
+  fi
+
+  echo $$ > "$LOCK_DIR/pid" 2>/dev/null
+  trap 'rm -rf "$LOCK_DIR" 2>/dev/null' EXIT
+
+  # ── Pull latest ──
+  OLD_HEAD=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null)
+  git -C "$REPO_DIR" pull --ff-only -q 2>/dev/null
+  PULL_EXIT=$?
+  NEW_HEAD=$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null)
+
+  # Record check time regardless of outcome
+  date +%s > "$THROTTLE_FILE" 2>/dev/null
+
+  if [ "$PULL_EXIT" -ne 0 ]; then
+    log_entry "PULL_FAILED exit=$PULL_EXIT"
+    exit 0
+  fi
+
+  if [ "$OLD_HEAD" != "$NEW_HEAD" ]; then
+    log_entry "UPDATING old=$OLD_HEAD new=$NEW_HEAD"
+
+    OLD_VER=$(git -C "$REPO_DIR" show "$OLD_HEAD:VERSION" 2>/dev/null | head -n1 | tr -d '[:space:]' || echo "unknown")
+
+    ( cd "$REPO_DIR" && ./setup -q ) >/dev/null 2>&1 || log_entry "SETUP_FAILED"
+
+    echo "$OLD_VER" > "$STATE_DIR/just-upgraded-from" 2>/dev/null
+    rm -f "$STATE_DIR/last-update-check" 2>/dev/null
+    rm -f "$STATE_DIR/update-snoozed" 2>/dev/null
+
+    NEW_VER=$(head -n1 "$REPO_DIR/VERSION" 2>/dev/null | tr -d '[:space:]' || echo "unknown")
+    log_entry "UPDATED from=$OLD_VER to=$NEW_VER"
+  else
+    log_entry "UP_TO_DATE head=$OLD_HEAD"
+  fi
+) &
+
+exit 0

--- a/setup
+++ b/setup
@@ -1,23 +1,33 @@
 #!/usr/bin/env bash
 # my-skills setup — symlink skills into ~/.claude/skills and install the
-# SessionStart auto-update-check hook.
+# SessionStart auto-update hook.
 #
 # Usage:
 #   ./setup              install/repair (idempotent)
-#   ./setup --uninstall  remove symlinks + hook entry
+#   ./setup -q           quiet mode (used by the session-update hook)
+#   ./setup --uninstall  remove symlinks + hook entry + CLAUDE.md block
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$REPO_DIR")"
 SETTINGS="$HOME/.claude/settings.json"
 CLAUDE_MD="$HOME/.claude/CLAUDE.md"
-HOOK_CMD="$REPO_DIR/bin/my-skills-update-check"
+HOOK_CMD="$REPO_DIR/bin/my-skills-session-update"
+LEGACY_HOOK_CMD="$REPO_DIR/bin/my-skills-update-check"
 BLOCK_BEGIN="<!-- BEGIN my-skills -->"
 BLOCK_END="<!-- END my-skills -->"
 REPO_URL="https://github.com/hiboute/my-skills.git"
 
 UNINSTALL=0
-[ "${1:-}" = "--uninstall" ] && UNINSTALL=1
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --uninstall) UNINSTALL=1 ;;
+    -q|--quiet) QUIET=1 ;;
+  esac
+done
+
+log() { [ "$QUIET" -eq 1 ] || echo "$@"; }
 
 # ─── Discover skills (every dir at repo root with a SKILL.md) ────────
 discover_skills() {
@@ -41,13 +51,13 @@ link_skills() {
     if [ -L "$target" ]; then
       current="$(readlink "$target")"
       if [ "$current" = "$src" ]; then
-        echo "ok:   $name (already linked)"
+        log "ok:   $name (already linked)"
         continue
       fi
       rm "$target"
     fi
     ln -s "$src" "$target"
-    echo "link: $name -> $src"
+    log "link: $name -> $src"
   done
 }
 
@@ -56,7 +66,7 @@ unlink_skills() {
     target="$SKILLS_DIR/$name"
     if [ -L "$target" ] && [ "$(readlink "$target")" = "$REPO_DIR/$name" ]; then
       rm "$target"
-      echo "rm:   $name"
+      log "rm:   $name"
     fi
   done
 }
@@ -80,29 +90,31 @@ install_hook() {
   [ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
   settings_backup
 
-  # Append a new SessionStart entry only if no entry already runs our command.
-  jq --arg cmd "$HOOK_CMD" '
+  # 1. Drop any legacy entry pointing at the old update-check command.
+  # 2. Append our new entry only if not already present.
+  jq --arg cmd "$HOOK_CMD" --arg legacy "$LEGACY_HOOK_CMD" '
     .hooks //= {}
     | .hooks.SessionStart //= []
+    | .hooks.SessionStart |= map(select(all(.hooks[]?; .command != $legacy)))
     | if any(.hooks.SessionStart[]?; .hooks[]?.command == $cmd) then .
       else .hooks.SessionStart += [{
         "matcher": ".*",
         "hooks": [{ "type": "command", "command": $cmd }]
       }] end
   ' "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
-  echo "hook: SessionStart -> $HOOK_CMD"
+  log "hook: SessionStart -> $HOOK_CMD"
 }
 
 remove_hook() {
   ensure_jq
   [ -f "$SETTINGS" ] || return 0
   settings_backup
-  jq --arg cmd "$HOOK_CMD" '
+  jq --arg cmd "$HOOK_CMD" --arg legacy "$LEGACY_HOOK_CMD" '
     if .hooks.SessionStart? then
-      .hooks.SessionStart |= map(select(all(.hooks[]?; .command != $cmd)))
+      .hooks.SessionStart |= map(select(all(.hooks[]?; .command != $cmd and .command != $legacy)))
     else . end
   ' "$SETTINGS" > "${SETTINGS}.tmp" && mv "${SETTINGS}.tmp" "$SETTINGS"
-  echo "hook: removed SessionStart entry for my-skills"
+  log "hook: removed SessionStart entry for my-skills"
 }
 
 # ─── CLAUDE.md block (advertise skills + install/update commands) ───
@@ -140,7 +152,7 @@ install_claude_md() {
   fi
   render_block >> "$tmp"
   mv "$tmp" "$CLAUDE_MD"
-  echo "claude.md: block written to $CLAUDE_MD"
+  log "claude.md: block written to $CLAUDE_MD"
 }
 
 remove_claude_md() {
@@ -153,7 +165,7 @@ remove_claude_md() {
     !skip { print }
   ' "$CLAUDE_MD" > "$tmp"
   mv "$tmp" "$CLAUDE_MD"
-  echo "claude.md: removed my-skills block"
+  log "claude.md: removed my-skills block"
 }
 
 # ─── Mark scripts executable ────────────────────────────────────────
@@ -168,11 +180,11 @@ if [ "$UNINSTALL" -eq 1 ]; then
   unlink_skills
   remove_hook
   remove_claude_md
-  echo "uninstall complete (repo and ~/.my-skills/ left intact)"
+  log "uninstall complete (repo and ~/.my-skills/ left intact)"
 else
   chmod_bin
   link_skills
   install_hook
   install_claude_md
-  echo "setup complete"
+  log "setup complete"
 fi

--- a/setup
+++ b/setup
@@ -10,7 +10,11 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 SKILLS_DIR="$(dirname "$REPO_DIR")"
 SETTINGS="$HOME/.claude/settings.json"
+CLAUDE_MD="$HOME/.claude/CLAUDE.md"
 HOOK_CMD="$REPO_DIR/bin/my-skills-update-check"
+BLOCK_BEGIN="<!-- BEGIN my-skills -->"
+BLOCK_END="<!-- END my-skills -->"
+REPO_URL="https://github.com/hiboute/my-skills.git"
 
 UNINSTALL=0
 [ "${1:-}" = "--uninstall" ] && UNINSTALL=1
@@ -101,6 +105,57 @@ remove_hook() {
   echo "hook: removed SessionStart entry for my-skills"
 }
 
+# ─── CLAUDE.md block (advertise skills + install/update commands) ───
+render_block() {
+  printf '%s\n' "$BLOCK_BEGIN"
+  echo "Available my-skills skills:"
+  echo
+  for name in $(discover_skills); do
+    echo "/$name"
+  done
+  echo
+  echo "Install with: git clone $REPO_URL ~/.claude/skills/my-skills && ~/.claude/skills/my-skills/setup"
+  echo "Update with:  ~/.claude/skills/my-skills/bin/my-skills-upgrade"
+  printf '%s\n' "$BLOCK_END"
+}
+
+install_claude_md() {
+  mkdir -p "$(dirname "$CLAUDE_MD")"
+  [ -f "$CLAUDE_MD" ] || : > "$CLAUDE_MD"
+
+  local tmp
+  tmp="$(mktemp)"
+  # Strip any existing block (from start marker to end marker), collapsing
+  # trailing blank lines that result from the removal.
+  awk -v b="$BLOCK_BEGIN" -v e="$BLOCK_END" '
+    $0 == b { skip = 1; next }
+    skip && $0 == e { skip = 0; next }
+    !skip { print }
+  ' "$CLAUDE_MD" > "$tmp"
+
+  # Trim trailing blank lines, then add one blank line before the block.
+  if [ -s "$tmp" ]; then
+    sed -e :a -e '/^$/{$d;N;ba' -e '}' "$tmp" > "${tmp}.2" && mv "${tmp}.2" "$tmp"
+    printf '\n' >> "$tmp"
+  fi
+  render_block >> "$tmp"
+  mv "$tmp" "$CLAUDE_MD"
+  echo "claude.md: block written to $CLAUDE_MD"
+}
+
+remove_claude_md() {
+  [ -f "$CLAUDE_MD" ] || return 0
+  local tmp
+  tmp="$(mktemp)"
+  awk -v b="$BLOCK_BEGIN" -v e="$BLOCK_END" '
+    $0 == b { skip = 1; next }
+    skip && $0 == e { skip = 0; next }
+    !skip { print }
+  ' "$CLAUDE_MD" > "$tmp"
+  mv "$tmp" "$CLAUDE_MD"
+  echo "claude.md: removed my-skills block"
+}
+
 # ─── Mark scripts executable ────────────────────────────────────────
 chmod_bin() {
   for f in "$REPO_DIR"/bin/*; do
@@ -112,10 +167,12 @@ chmod_bin() {
 if [ "$UNINSTALL" -eq 1 ]; then
   unlink_skills
   remove_hook
+  remove_claude_md
   echo "uninstall complete (repo and ~/.my-skills/ left intact)"
 else
   chmod_bin
   link_skills
   install_hook
+  install_claude_md
   echo "setup complete"
 fi


### PR DESCRIPTION
## Summary

- Extend `setup` to manage a marker-delimited block in `~/.claude/CLAUDE.md` that lists installed skills and the install/update commands, so Claude discovers them the same way gstack does.
- Block is generated dynamically from `discover_skills()`, so new skills added to the repo show up on the next `./setup` run.
- `./setup --uninstall` removes the block; any content outside the `<!-- BEGIN/END my-skills -->` markers is preserved.

## Test plan

- [x] Fresh install writes block, preserves pre-existing CLAUDE.md content
- [x] Second `./setup` run is idempotent (single block, no duplicates)
- [x] `./setup --uninstall` strips the block and leaves user content intact
- [ ] Verify on a real `~/.claude/CLAUDE.md` with prior content
