### PR TITLE
chore(roadmap): use gh CLI directly, drop custom-MCP preference

### DIFF
--- a/roadmap/SKILL.md
+++ b/roadmap/SKILL.md
@@ -31,8 +31,8 @@ Before starting, make sure you have:
 
 1. **Target repository** in `owner/repo` form. If the user doesn't specify one, ask.
 2. **Project owner** — usually the same as the repo owner (user or org). GitHub Projects v2 live at the user/org level, not inside the repo. If the repo is under a personal account, the project owner defaults to that user; if under an org, default to the org. Only ask if it's ambiguous.
-3. **Codebase access** — either the local working directory is the project, or you can read it via `mcp__github__get_file_contents` / `search_code`.
-4. **Auth scope** — creating/editing Projects v2 requires the `project` OAuth scope (and `read:project` for reads). If using `gh`, the user may need `gh auth refresh -s project` first. If the first project call fails with a scope error, surface this clearly and stop.
+3. **Codebase access** — either the local working directory is the project, or you can read it remotely with `gh api repos/<owner>/<repo>/contents/<path>` and `gh search code`.
+4. **Auth scope** — creating/editing Projects v2 requires the `project` OAuth scope (and `read:project` for reads). The user may need `gh auth refresh -s project` first. If the first project call fails with a scope error, surface this clearly and stop.
 5. **Optional**: competitor analysis notes the user provides. If present, weave them in (see "Competitor insights" below).
 
 Confirm the repo + project owner once, then proceed autonomously. Do not ask clarifying questions about audience, vision, or priorities — infer them from the code, README, and package manifest. Making confident inferences is the whole point of this skill.

--- a/roadmap/references/github-mapping.md
+++ b/roadmap/references/github-mapping.md
@@ -6,13 +6,10 @@ Load this file after you have:
 
 ## Tools
 
-Use, in order of preference:
+Use the `gh` CLI for everything:
 
-1. **GitHub MCP tools** if the server in use exposes project-v2 helpers (e.g. `create_project`, `add_project_item`, `update_project_field`, `list_project_fields`). Names vary by MCP implementation — inspect what's available before committing.
-2. **`gh` CLI** (`gh project …`) as the portable fallback. Requires the `project` auth scope. If a command fails with a scope error, surface it and stop — ask the user to run `gh auth refresh -s project` and retry.
-3. **Raw GraphQL** via `gh api graphql` only if neither of the above covers a specific operation (e.g. creating a single-select option after field creation).
-
-The steps below use `gh` syntax for concreteness. Substitute MCP equivalents when available.
+1. **`gh` CLI** (`gh project …`, `gh issue …`, `gh label …`, `gh repo …`) for all typed operations. Requires the `project` auth scope for Projects v2 operations. If a command fails with a scope error, surface it and stop — ask the user to run `gh auth refresh -s project` and retry.
+2. **Raw GraphQL** via `gh api graphql` only for operations the typed commands don't cover (e.g. adding a single-select option to an existing field).
 
 ## Key GitHub Projects (v2) concepts
 


### PR DESCRIPTION
## Summary

- `references/github-mapping.md` — replaces the three-tier "GitHub MCP tools → gh → graphql" preference list with a two-tier one: `gh` CLI first, `gh api graphql` as the fallback. Removes the "Substitute MCP equivalents when available" guidance since there's nothing to substitute anymore.
- `SKILL.md` — codebase-access input no longer mentions `mcp__github__get_file_contents` / `search_code`; points at `gh api repos/.../contents/...` and `gh search code` instead. The auth-scope bullet was tightened (the "if using gh" conditional is moot).

## Why

`gh` is available wherever this skill runs now, and the existing `hiboute/mcp` GitHub server is itself a thin `gh` wrapper — the "prefer MCP if it exposes project-v2 helpers" branch was never a meaningful path. Simpler to write the skill against one concrete tool.

No behavior changes in the Publishing steps — those already use `gh` syntax throughout.