### PR TITLE
chore(setup): adopt gstack's real-dir + SKILL.md-symlink pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,25 @@
-# my-skills — CLAUDE.md block
+# my-skills — repo notes for Claude
 
-The `setup` script manages a marker-delimited block inside
+## Install pattern
+
+This repo follows [gstack](https://github.com/garrytan/gstack)'s symlink pattern
+for Claude skills. The repo is cloned to `~/.claude/skills/my-skills/`, then for
+each skill folder with a `SKILL.md`, `setup` creates:
+
+- A real directory at `~/.claude/skills/<name>/`
+- A `SKILL.md` symlink inside it, pointing to this repo's
+  `<skill>/SKILL.md`
+
+Skill name comes from the frontmatter `name:` field (falling back to the dir
+name). Sibling content inside a skill (e.g. `categories/*.md`,
+`references/*.md`) is addressed inside SKILL.md via absolute paths
+(`~/.claude/skills/my-skills/<skill>/<path>`), because only `SKILL.md` is linked
+into `~/.claude/skills/`. That is gstack's convention — don't rewrite sibling
+references back to relative paths.
+
+## CLAUDE.md block
+
+The `setup` script also manages a marker-delimited block inside
 `~/.claude/CLAUDE.md`. The block tells Claude which `my-skills` are installed
 and how to install/update them. It's regenerated on every `./setup` run so
 newly added skills show up automatically.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,15 @@ git clone https://github.com/hiboute/my-skills.git ~/.claude/skills/my-skills
 ```
 
 `setup` does four things:
-1. Creates symlinks `~/.claude/skills/<skill>` → `~/.claude/skills/my-skills/<skill>`
-   for every skill folder in this repo.
+1. For every skill folder in this repo, creates a real directory at
+   `~/.claude/skills/<skill>/` containing a single symlink
+   `SKILL.md` → `~/.claude/skills/my-skills/<skill>/SKILL.md`. This is the same
+   pattern used by [gstack](https://github.com/garrytan/gstack) — it lets Claude
+   discover the skill at the top level of `~/.claude/skills/` (so it's reachable
+   as `/ideation`, not `/my-skills/ideation`) while the actual content stays in
+   the cloned repo. Any legacy whole-directory symlink left by an earlier
+   install is migrated in place. Skill name comes from the SKILL.md `name:`
+   frontmatter field, with the directory name as fallback.
 2. Marks scripts in `bin/` executable.
 3. Installs a `SessionStart` hook in `~/.claude/settings.json` that, on each
    Claude Code session start, forks a background job which `git pull`s the repo,
@@ -32,6 +39,11 @@ git clone https://github.com/hiboute/my-skills.git ~/.claude/skills/my-skills
    skills and the install/update commands, so Claude knows they exist. The block
    is regenerated on every run; any content outside the `<!-- BEGIN/END my-skills -->`
    markers is preserved.
+
+Because only `SKILL.md` is symlinked, skill files that reference sibling content
+(like `categories/…` or `references/…`) must use absolute paths inside the
+cloned repo: `~/.claude/skills/my-skills/<skill>/<path>`. Same convention as
+gstack's SKILL.md files.
 
 Re-run `setup` any time to repair links, refresh the CLAUDE.md block, or pick up
 newly added skills.
@@ -85,8 +97,10 @@ periodic auto-update stops.
 ~/.claude/skills/my-skills/setup --uninstall
 ```
 
-Removes symlinks, the hook entry, and the CLAUDE.md block. Leaves the repo dir
-and `~/.my-skills/` alone in case you want to reinstall.
+Removes the per-skill directories we own (those whose `SKILL.md` is a symlink
+pointing into this repo), any leftover legacy symlinks, the SessionStart hook
+entry, and the CLAUDE.md block. Leaves the repo dir and `~/.my-skills/` alone
+in case you want to reinstall.
 
 ## License
 

--- a/ideation/SKILL.md
+++ b/ideation/SKILL.md
@@ -13,12 +13,12 @@ Pick the mode that matches the user's intent. If they don't specify, ask which o
 
 | Mode | Focuses on | Load |
 |---|---|---|
-| `security` | OWASP-style vulnerabilities, secrets, unsafe inputs | `categories/security.md` |
-| `performance` | Bundle size, runtime, memory, DB, network, rendering, caching | `categories/performance.md` |
-| `documentation` | README, API docs, inline comments, examples, architecture, troubleshooting | `categories/documentation.md` |
-| `code-quality` | Large files, code smells, complexity, duplication, naming, structure, linting, tests, types, dead code | `categories/code-quality.md` |
-| `code-improvements` | Code-revealed feature opportunities extending existing patterns | `categories/code-improvements.md` |
-| `ui-ux` | Usability, accessibility, perceived performance, visual polish, interactions | `categories/ui-ux.md` |
+| `security` | OWASP-style vulnerabilities, secrets, unsafe inputs | `~/.claude/skills/my-skills/ideation/categories/security.md` |
+| `performance` | Bundle size, runtime, memory, DB, network, rendering, caching | `~/.claude/skills/my-skills/ideation/categories/performance.md` |
+| `documentation` | README, API docs, inline comments, examples, architecture, troubleshooting | `~/.claude/skills/my-skills/ideation/categories/documentation.md` |
+| `code-quality` | Large files, code smells, complexity, duplication, naming, structure, linting, tests, types, dead code | `~/.claude/skills/my-skills/ideation/categories/code-quality.md` |
+| `code-improvements` | Code-revealed feature opportunities extending existing patterns | `~/.claude/skills/my-skills/ideation/categories/code-improvements.md` |
+| `ui-ux` | Usability, accessibility, perceived performance, visual polish, interactions | `~/.claude/skills/my-skills/ideation/categories/ui-ux.md` |
 
 Each mode has its own analysis methodology, severity/impact scale, and issue template. Load only the mode the user picked — don't preload all six.
 
@@ -50,11 +50,11 @@ Confirm the target + mode once, then proceed autonomously.
 
 ## Pipeline
 
-1. **Load the mode file** (`categories/<mode>.md`). It contains the specific analysis steps, severity scale, and issue-body template for that mode.
+1. **Load the mode file** (`~/.claude/skills/my-skills/ideation/categories/<mode>.md`). It contains the specific analysis steps, severity scale, and issue-body template for that mode.
 2. **Analyze the codebase.** Read files, run searches, look at dependencies. Follow the methodology in the mode file.
 3. **Shortlist findings.** Aim for the 3–7 most impactful, non-duplicate, actionable issues. If you find 20 candidates, pick the 5 best — don't dump everything.
 4. **Check existing issues.** For each finding, scan open issues in the repo. If something similar is already tracked, skip the finding or note it as a duplicate in the summary.
-5. **Publish.** Load `references/github-mapping.md` and create one GitHub issue per finding, with the labels and body format from the mode file.
+5. **Publish.** Load `~/.claude/skills/my-skills/ideation/references/github-mapping.md` and create one GitHub issue per finding, with the labels and body format from the mode file.
 6. **Summarize.** Print a Markdown summary back to the user with a link to each created issue.
 
 ## Operating rules
@@ -89,4 +89,4 @@ Before reading the full mode file, remember:
 - **code-improvements** uses `effort: trivial | small | medium | large | complex` — this is the one mode that finds *features* the code reveals, not defects
 - **ui-ux** uses five categories (usability, accessibility, performance, visual, interaction) and is the only mode that benefits from running the app in a browser (optional)
 
-For full rules, templates, and GitHub label schemas, load `references/github-mapping.md` alongside the mode file.
+For full rules, templates, and GitHub label schemas, load `~/.claude/skills/my-skills/ideation/references/github-mapping.md` alongside the mode file.

--- a/roadmap/SKILL.md
+++ b/roadmap/SKILL.md
@@ -10,7 +10,7 @@ Analyze a codebase, infer its audience and vision, then generate a MoSCoW-priori
 The skill runs in one of two **modes**, chosen automatically:
 
 - **Greenfield** — no existing roadmap project for this repo. Creates the project, fills it with 5–10 features across 3–4 phases, all tagged as `Sprint 1`.
-- **Incremental** — a `<Repo name> Roadmap` project already exists. Reads the current board state (done/in-progress/open counts, per-phase completion), then generates **3–7 new features** as the next sprint (`Sprint N+1`). New features usually reuse the existing phases, but the skill **can open a new phase** (`Phase N+1 — <Theme>`) when the batch genuinely belongs to a new strategic theme — see the trigger rules in `references/github-mapping.md`. Existing items are left alone. The skill is safe to re-run: each run adds one sprint on top of whatever's there, and optionally a new phase.
+- **Incremental** — a `<Repo name> Roadmap` project already exists. Reads the current board state (done/in-progress/open counts, per-phase completion), then generates **3–7 new features** as the next sprint (`Sprint N+1`). New features usually reuse the existing phases, but the skill **can open a new phase** (`Phase N+1 — <Theme>`) when the batch genuinely belongs to a new strategic theme — see the trigger rules in `~/.claude/skills/my-skills/roadmap/references/github-mapping.md`. Existing items are left alone. The skill is safe to re-run: each run adds one sprint on top of whatever's there, and optionally a new phase.
 
 ## When to use
 
@@ -59,18 +59,18 @@ Infer, in order:
 6. **Competitive context** — alternatives, differentiators, market position
 7. **Constraints** — technical, resources, dependencies
 
-For the detailed methodology and what to look for at each step, load `references/discovery.md`.
+For the detailed methodology and what to look for at each step, load `~/.claude/skills/my-skills/roadmap/references/discovery.md`.
 
 **Hold the discovery object in memory** — you don't need to write it to disk. It's the input to Phase 2.
 
 ### Phase 2 — Features + Publishing
 
-First, **detect the mode**. Try to find an existing `<Repo name> Roadmap` project for the owner. If one exists, you're in incremental mode — see `references/github-mapping.md` → "State analysis (incremental mode)" to read the current board before brainstorming. That analysis becomes extra input alongside the discovery object.
+First, **detect the mode**. Try to find an existing `<Repo name> Roadmap` project for the owner. If one exists, you're in incremental mode — see `~/.claude/skills/my-skills/roadmap/references/github-mapping.md` → "State analysis (incremental mode)" to read the current board before brainstorming. That analysis becomes extra input alongside the discovery object.
 
 Then generate features. The target count depends on mode:
 
 - **Greenfield** — generate **5–10 features** organized into **3–4 phases**, all tagged for `Sprint 1`.
-- **Incremental** — generate **3–7 new features** as the next sprint (`Sprint N+1`). Default to reusing existing phases; opening a new phase (`Phase N+1`) is allowed only when the trigger rules in `references/github-mapping.md` §2.5.4 are met (explicit user ask, or a coherent new theme with ≥2 features when earlier phases are mostly Done). Do **not** re-file features that already exist as open items on the board.
+- **Incremental** — generate **3–7 new features** as the next sprint (`Sprint N+1`). Default to reusing existing phases; opening a new phase (`Phase N+1`) is allowed only when the trigger rules in `~/.claude/skills/my-skills/roadmap/references/github-mapping.md` §2.5.4 are met (explicit user ask, or a coherent new theme with ≥2 features when earlier phases are mostly Done). Do **not** re-file features that already exist as open items on the board.
 
 For each feature, produce:
 - `title` — short, action-oriented
@@ -83,7 +83,7 @@ For each feature, produce:
 - `user_stories` — "As a <persona>, I want to <action> so that <benefit>"
 - `dependencies` — feature titles this one needs first (can reference existing open issues on the board)
 
-Organize features into phases in this shape (greenfield creates the full structure; incremental mode reuses existing phases and may add a new one — see `references/github-mapping.md` for the trigger rules):
+Organize features into phases in this shape (greenfield creates the full structure; incremental mode reuses existing phases and may add a new one — see `~/.claude/skills/my-skills/roadmap/references/github-mapping.md` for the trigger rules):
 - **Phase 1 — Foundation / MVP** — must-haves, quick wins
 - **Phase 2 — Enhancement** — should-haves, UX improvements
 - **Phase 3 — Scale / Growth** — could-haves, advanced features
@@ -95,16 +95,16 @@ Prioritization rules:
 - Nice-to-have + low complexity → `could` / Phase 2–3 (fill-ins)
 - Nice-to-have + high complexity → `wont` or Phase 4 (avoid)
 
-For the prioritization framework and feature-brainstorming prompts, load `references/features.md`.
+For the prioritization framework and feature-brainstorming prompts, load `~/.claude/skills/my-skills/roadmap/references/features.md`.
 
-**Then publish to a GitHub Project.** The mapping between roadmap structures and GitHub artifacts (project creation, custom fields to create, labels, issue body template, dependency links) is in `references/github-mapping.md` — load it before you start creating anything.
+**Then publish to a GitHub Project.** The mapping between roadmap structures and GitHub artifacts (project creation, custom fields to create, labels, issue body template, dependency links) is in `~/.claude/skills/my-skills/roadmap/references/github-mapping.md` — load it before you start creating anything.
 
 ## Operating rules
 
 1. **Non-interactive by default.** Don't ask the user to fill gaps in discovery — infer them. The only things you may confirm are the target repo and the project owner. The user may also steer an incremental run ("focus this sprint on performance") — honor that as a bias during feature generation.
 2. **Mode is decided automatically.** Existing `<Repo name> Roadmap` project → incremental. No project → greenfield. Don't ask which mode to run in.
 3. **Idempotent project setup.** If a project with the intended title already exists for the owner, reuse it rather than creating a duplicate. Same for custom fields and single-select options — list before creating, treat "already exists" as success.
-4. **Existing items are read-only.** In incremental mode, never edit fields on existing items, never re-file their issues, never change their sprint or phase tag. Adding new **options** to the Phase or Sprint single-select fields is allowed (and is how sprints/phases extend) — that's a field-level change, not an item-level one. The one item-level exception: the first time the Sprint field is created on a pre-existing project, backfill all existing items as `Sprint 1` (see `references/github-mapping.md`).
+4. **Existing items are read-only.** In incremental mode, never edit fields on existing items, never re-file their issues, never change their sprint or phase tag. Adding new **options** to the Phase or Sprint single-select fields is allowed (and is how sprints/phases extend) — that's a field-level change, not an item-level one. The one item-level exception: the first time the Sprint field is created on a pre-existing project, backfill all existing items as `Sprint 1` (see `~/.claude/skills/my-skills/roadmap/references/github-mapping.md`).
 5. **Don't duplicate existing issues.** Before filing, list open issues in the repo and skip or merge with anything that already describes the same feature. For duplicates, still add the existing issue to the project and set its fields (greenfield only) — that way the board reflects reality.
 6. **Create labels idempotently.** If a label already exists, reuse it. Never error on a duplicate-label response.
 7. **Draft-friendly.** Create issues as normal (not draft) but set the project Status field to `Todo` and label them `status:idea` so the user can triage before committing to them.
@@ -116,7 +116,7 @@ For the prioritization framework and feature-brainstorming prompts, load `refere
 If the user supplies competitor analysis (either inline or by pointing to a file), use it to:
 - Populate the `competitive_context` part of the discovery
 - Boost priority on features that directly address competitor pain points
-- Tag those issues with the `competitor-insight` label and mention the specific competitor + pain point in the issue body's rationale. Also set the `Competitor` text field on the project item if it was created (see `references/github-mapping.md`).
+- Tag those issues with the `competitor-insight` label and mention the specific competitor + pain point in the issue body's rationale. Also set the `Competitor` text field on the project item if it was created (see `~/.claude/skills/my-skills/roadmap/references/github-mapping.md`).
 
 No competitor data → skip this entirely. Don't invent competitors.
 

--- a/setup
+++ b/setup
@@ -30,43 +30,80 @@ done
 log() { [ "$QUIET" -eq 1 ] || echo "$@"; }
 
 # ─── Discover skills (every dir at repo root with a SKILL.md) ────────
+# Emits one "<dir_name> <skill_name>" line per skill. skill_name comes from the
+# SKILL.md `name:` frontmatter field, with the directory name as fallback.
+# Matches gstack's link_claude_skill_dirs behavior.
 discover_skills() {
   for d in "$REPO_DIR"/*/; do
-    name="$(basename "$d")"
+    dir_name="$(basename "$d")"
     [ -f "$d/SKILL.md" ] || continue
-    echo "$name"
+    skill_name=$(grep -m1 '^name:' "$d/SKILL.md" 2>/dev/null \
+      | sed 's/^name:[[:space:]]*//' | tr -d '[:space:]')
+    [ -z "$skill_name" ] && skill_name="$dir_name"
+    echo "$dir_name $skill_name"
   done
 }
 
+# Gstack-style link: create a real directory at $SKILLS_DIR/<skill_name>/ with
+# a SKILL.md symlink inside pointing at the repo. Claude discovers the skill at
+# the top level of ~/.claude/skills/ rather than nested under my-skills/.
+# Sibling files (categories/, references/) are addressed via absolute paths
+# inside SKILL.md — no sidecar symlinks needed.
 link_skills() {
-  for name in $(discover_skills); do
-    target="$SKILLS_DIR/$name"
-    src="$REPO_DIR/$name"
-    # Skip if a non-symlink dir with the same name already exists
-    if [ -e "$target" ] && [ ! -L "$target" ]; then
-      echo "skip: $target exists and is not a symlink" >&2
+  discover_skills | while read -r dir_name skill_name; do
+    target="$SKILLS_DIR/$skill_name"
+    src_skill_md="$REPO_DIR/$dir_name/SKILL.md"
+
+    # Migrate legacy whole-directory symlinks (old my-skills pattern).
+    if [ -L "$target" ]; then
+      rm "$target"
+      log "migrate: removed legacy symlink at $target"
+    fi
+
+    # If target already exists as a real dir, verify it's ours before touching.
+    # A dir we own has SKILL.md as a symlink pointing into this repo.
+    if [ -d "$target" ] && [ ! -L "$target" ]; then
+      existing_link="$(readlink "$target/SKILL.md" 2>/dev/null || true)"
+      case "$existing_link" in
+        "$REPO_DIR"/*) : ;;  # ours, safe to update
+        "")
+          echo "skip: $target exists and is not managed by my-skills" >&2
+          continue
+          ;;
+      esac
+    fi
+
+    mkdir -p "$target"
+    # Replace SKILL.md symlink idempotently (avoid ln -snf on a regular file).
+    [ -L "$target/SKILL.md" ] && rm "$target/SKILL.md"
+    ln -s "$src_skill_md" "$target/SKILL.md"
+    log "link: $skill_name -> $src_skill_md"
+  done
+}
+
+# Remove directories we own: a real dir whose only managed content is a
+# SKILL.md symlink pointing into this repo. Leave everything else alone.
+unlink_skills() {
+  discover_skills | while read -r dir_name skill_name; do
+    target="$SKILLS_DIR/$skill_name"
+
+    # Legacy whole-dir symlink from an older install.
+    if [ -L "$target" ] && [ "$(readlink "$target")" = "$REPO_DIR/$dir_name" ]; then
+      rm "$target"
+      log "rm:   $skill_name (legacy symlink)"
       continue
     fi
-    # Replace stale symlinks
-    if [ -L "$target" ]; then
-      current="$(readlink "$target")"
-      if [ "$current" = "$src" ]; then
-        log "ok:   $name (already linked)"
-        continue
-      fi
-      rm "$target"
-    fi
-    ln -s "$src" "$target"
-    log "link: $name -> $src"
-  done
-}
 
-unlink_skills() {
-  for name in $(discover_skills); do
-    target="$SKILLS_DIR/$name"
-    if [ -L "$target" ] && [ "$(readlink "$target")" = "$REPO_DIR/$name" ]; then
-      rm "$target"
-      log "rm:   $name"
+    # Real dir owned by us: SKILL.md is a symlink into this repo.
+    if [ -d "$target" ] && [ ! -L "$target" ]; then
+      existing_link="$(readlink "$target/SKILL.md" 2>/dev/null || true)"
+      case "$existing_link" in
+        "$REPO_DIR"/*)
+          rm -f "$target/SKILL.md"
+          rmdir "$target" 2>/dev/null && log "rm:   $skill_name" \
+            || log "skip: $target has extra files, leaving in place"
+          ;;
+      esac
     fi
   done
 }
@@ -122,9 +159,7 @@ render_block() {
   printf '%s\n' "$BLOCK_BEGIN"
   echo "Available my-skills skills:"
   echo
-  for name in $(discover_skills); do
-    echo "/$name"
-  done
+  discover_skills | awk '{print "/" $2}'
   echo
   echo "Install with: git clone $REPO_URL ~/.claude/skills/my-skills && ~/.claude/skills/my-skills/setup"
   echo "Update with:  ~/.claude/skills/my-skills/bin/my-skills-upgrade"


### PR DESCRIPTION
## Summary

- Install pattern now mirrors [gstack](https://github.com/garrytan/gstack) exactly: each skill installs as a **real directory** at `~/.claude/skills/<name>/` containing only a `SKILL.md` **symlink** into the cloned repo (replacing the previous whole-directory symlink). Skill name resolves from the `name:` frontmatter field with the directory name as fallback.
- Rewrote every sibling-file reference in `ideation/SKILL.md` and `roadmap/SKILL.md` from relative (`categories/security.md`) to absolute (`~/.claude/skills/my-skills/ideation/categories/security.md`). This is gstack's convention — only `SKILL.md` is linked, so relative paths to `categories/` or `references/` would miss.
- Legacy whole-dir symlinks from earlier installs are migrated in place on the next `setup` run (logs `migrate: removed legacy symlink at …`). `--uninstall` understands both the new and legacy layouts.
- Updated README and CLAUDE.md to document the pattern and warn future edits not to regress absolute paths back to relative ones.

## Test plan

- [x] `./setup` on a clean tree → creates real dir + SKILL.md symlink, matches `ls -la ~/.claude/skills/qa/` (live gstack skill)
- [x] `./setup` on a legacy whole-dir-symlink tree → migrates and logs `migrate: …`
- [x] `./setup --uninstall` → removes only directories whose SKILL.md points into this repo; leaves unrelated content alone; strips the hook and CLAUDE.md block
- [x] `bash -n setup` passes
- [x] No relative sibling references remain in SKILL.md files (`grep -nE "\`categories/|\`references/"` is clean)

## Upgrade note

Existing installs at `~/.claude/skills/my-skills/` will pick this up after a
`git pull` via the `SessionStart` hook (or manual
`~/.claude/skills/my-skills/bin/my-skills-upgrade`). The migration is automatic
on the next `setup` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)