### PR TITLE
feat(autopilot): add autonomous plan → implement → AI-review skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Available hiboute skills:
 
 - '/ideation'
 - '/roadmap'
+- '/autopilot'
 
 Install with: 'git clone https://github.com/hiboute/my-skills.git ~/.claude/skills/my-skills && ~/.claude/skills/my-skills/setup'
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Pattern inspired by [garrytan/gstack](https://github.com/garrytan/gstack).
   findings to GitHub as labeled issues.
 - **roadmap** — Generate a strategic product roadmap and publish it to a GitHub
   Project (v2). Re-runnable: each call adds one new sprint, optionally a new phase.
+- **autopilot** — Autonomously build a feature end-to-end via a three-phase
+  pipeline: plan → implement (in an isolated git worktree) → AI review with a
+  bounded fix loop. Each phase runs as a fresh-context subagent. Pipeline pattern
+  inspired by [AndyMik90/Aperant](https://github.com/AndyMik90/Aperant).
 
 ## Install
 

--- a/autopilot/SKILL.md
+++ b/autopilot/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: autopilot
+description: Autonomously build a feature end-to-end — plan, implement in an isolated git worktree, then run an independent AI review with a bounded fix loop. Orchestrates three phases as fresh-context subagents so the main session stays focused on coordination. Use when the user asks to "ship feature X autonomously", "build this end-to-end", "plan and implement then review", "take this issue from spec to PR", or gives a feature description they want delivered without further step-by-step guidance. Pattern inspired by Aperant (AndyMik90/Aperant).
+---
+
+# Autopilot
+
+Take a feature request from description to reviewed, diff-ready implementation. The skill runs a three-phase pipeline — **plan → implement → AI review** — with each phase dispatched as a subagent so the orchestrator session stays lean. If the review finds issues, a bounded fix loop runs before surfacing anything to the user.
+
+This is the small-team-in-a-skill version of Aperant's autonomous build pipeline.
+
+## When to use
+
+Trigger on requests like:
+- "Build <feature> autonomously"
+- "Take this issue and ship it end-to-end"
+- "Plan, implement, then review <thing>"
+- "Do <feature> for me, I'll review at the end"
+- "Run the full pipeline on <ask>"
+
+Do **not** use for:
+- Single-file edits or obvious one-line fixes → just do it, skip the pipeline.
+- Debugging an existing bug → use the `superpowers:systematic-debugging` skill.
+- Strategic planning or roadmap work → use the `roadmap` skill.
+- Finding issues to file, not fixing them → use the `ideation` skill.
+- Features that need live product input from the user partway through → do it interactively instead.
+
+## Inputs
+
+Before starting, gather:
+
+1. **Feature ask** — a description, a GitHub issue URL/number, or a spec file path. If the ask is one vague sentence, ask one clarifying question, then proceed.
+2. **Target branch** — the base branch to diff against and eventually merge into. Default to `main`; honor the project's convention if `develop` or similar is used (check recent PR titles or `CONTRIBUTING.md`).
+3. **Working directory** — the repo root. Must be a git repo. If the tree is dirty, surface that and ask before proceeding — the pipeline assumes a clean base.
+4. **Scope hints** (optional) — "keep it prompt-only", "don't touch tests", "reuse existing X". Pass these verbatim into each phase agent.
+
+Confirm the feature ask + base branch once, then proceed autonomously through the three phases.
+
+## Pipeline
+
+Each phase dispatches a fresh-context subagent via the `Agent` tool. The orchestrator (you) stays at the coordination layer: briefing agents, reading their summaries, deciding whether to advance or iterate.
+
+### Phase 1 — Plan
+
+Dispatch a **planning agent** with `subagent_type: Plan` (or `general-purpose` if Plan isn't available). The agent produces a written plan covering:
+
+- Problem statement (1–3 sentences)
+- Files to create / modify, with a one-line purpose each
+- Public API or interface changes, if any
+- Test strategy (what to add, what to modify)
+- Independent workstreams that can be parallelized in Phase 2, if any
+- Risks / unknowns
+
+Full briefing rules and the plan contract: `~/.claude/skills/my-skills/autopilot/references/plan-phase.md`.
+
+Print the plan back to the user and **ask for confirmation before Phase 2**. The user may edit the plan, drop scope, or request changes. If they do, re-dispatch the planning agent with their feedback.
+
+Skip the confirmation prompt only if the user explicitly said "don't stop to confirm" or similar in their original ask.
+
+### Phase 2 — Implement
+
+Set up isolation: either use the `Agent` tool with `isolation: "worktree"` or invoke the `superpowers:using-git-worktrees` skill to create one manually before dispatch. Main branch never gets touched directly.
+
+Dispatch an **implementation agent** (`subagent_type: general-purpose`) with:
+- The approved plan (verbatim)
+- The feature ask (verbatim)
+- Explicit instruction to follow the plan, write tests per the plan's test strategy, and run the project's test command before declaring done
+- A request for a concise final summary (under 300 words): what files changed, what tests were added/modified, any plan deviations with reasons
+
+If the plan flagged independent workstreams, dispatch them in parallel — one subagent per workstream, single message with multiple `Agent` tool calls. Each subagent gets its slice of the plan plus shared context (types, conventions).
+
+Full briefing rules and parallelization heuristics: `~/.claude/skills/my-skills/autopilot/references/implement-phase.md`.
+
+### Phase 3 — AI review (with bounded fix loop)
+
+Dispatch a **review agent** (`subagent_type: pr-review-toolkit:code-reviewer` if available, else `feature-dev:code-reviewer`, else `general-purpose`). Brief it with:
+- The original feature ask
+- The plan
+- The diff against the base branch
+- Instruction to find bugs, logic errors, test gaps, security issues, and plan deviations
+- A request for findings categorized by severity: `blocking` / `should-fix` / `nit`, with file:line citations
+
+Collect the findings. **Decision tree**:
+
+- **No `blocking` or `should-fix` findings** — pipeline done. Summarize and hand off.
+- **Some `blocking` or `should-fix` findings, iteration count < 2** — dispatch a **fix agent** (`general-purpose`) with the findings and the existing diff context. After the fix agent returns, re-run the review agent on the updated diff. Cap at 2 fix iterations.
+- **Iteration cap hit with findings remaining** — stop. Surface remaining findings to the user with a clear "pipeline hit the 2-round fix cap" note. Don't iterate further without explicit go-ahead.
+
+Full briefing rules and the severity scale: `~/.claude/skills/my-skills/autopilot/references/review-phase.md`.
+
+## Operating rules
+
+1. **Orchestrator-first.** You coordinate; agents execute. Don't read files or write code yourself during phases 2–3 unless an agent explicitly failed — delegation keeps the main context clean.
+2. **Fresh context per phase.** Each phase agent gets only the inputs it needs. Don't forward the previous agent's full transcript — forward its summary plus the plan/ask.
+3. **Worktree isolation on implementation.** Never implement against the main working tree. Use `isolation: "worktree"` on the implementation agent or set up a worktree first via the `superpowers:using-git-worktrees` skill.
+4. **One confirmation gate.** After Phase 1. Not before or after other phases. The whole point of the skill is autonomy — gating at every step defeats it.
+5. **Bounded fix loop.** At most 2 fix rounds before surfacing to the user. Infinite iteration hides real problems.
+6. **Parallel only when independent.** If workstreams share files or depend on each other's types/APIs, run them sequentially. Spurious parallelism produces merge conflicts and context drift.
+7. **Don't invent plan deviations.** If the implementation agent couldn't follow the plan, its summary should say why — don't paper over that in your report to the user.
+8. **Preserve the user's scope hints.** If they said "prompt-only" or "don't touch tests", forward that verbatim to every phase agent. Agents lose that nuance without explicit reminders.
+9. **One feature per run.** If the ask bundles multiple independent features, ask the user to split them or pick one.
+
+## Output contract
+
+At the end of a successful run:
+- **Plan** — printed inline to the user after Phase 1 (for approval) and included in the final summary.
+- **Branch / worktree** — named something recognizable (`autopilot/<short-slug>`), ahead of the base branch with the implementation commits.
+- **Diff** — committed on the branch. Tests pass per the plan's test strategy.
+- **Review report** — the final review pass's findings, with severities. Included in the final summary.
+- **Fix log** (if any) — one-line summary per fix round, e.g. `round 1: addressed 2 blocking + 1 should-fix, re-review clean`.
+- **Final handoff** — a markdown summary back to the user with: feature ask, branch/worktree path, commits, diff stats, test results, review status, and any open findings that hit the iteration cap.
+
+No GitHub PR is opened by this skill — handoff is the branch/worktree. Use `/ship` (gstack) or manual `gh pr create` to ship it.
+
+## Failure handling
+
+- **Planning agent returns something vague** — re-dispatch once with explicit feedback. If it's still vague, stop and tell the user the ask is underspecified.
+- **Implementation agent reports it couldn't finish** — read its summary, decide whether to dispatch a follow-up with clarified scope, ask the user, or surface the blocker.
+- **Test command fails and the implementation agent didn't notice** — dispatch a fix agent with the test output. Count this toward the 2-round fix cap.
+- **Review agent itself looks wrong** (produces obviously bad findings) — dispatch it once more with a sharper brief. If still bad, summarize what you have and flag the review quality in the handoff.
+
+## Attribution
+
+Pipeline pattern ported from [Aperant](https://github.com/AndyMik90/Aperant) (AndyMik90) — an Electron-based autonomous coding framework. This skill is the in-session, single-Claude-Code-conversation adaptation of their orchestrator → planner → coder → QA workflow.

--- a/autopilot/SKILL.md
+++ b/autopilot/SKILL.md
@@ -20,7 +20,8 @@ Trigger on requests like:
 
 Do **not** use for:
 - Single-file edits or obvious one-line fixes → just do it, skip the pipeline.
-- Debugging an existing bug → use the `superpowers:systematic-debugging` skill.
+- Debugging an existing bug → investigate and patch it directly; the autopilot
+  phases are designed for net-new feature work, not root-cause chases.
 - Strategic planning or roadmap work → use the `roadmap` skill.
 - Finding issues to file, not fixing them → use the `ideation` skill.
 - Features that need live product input from the user partway through → do it interactively instead.
@@ -59,7 +60,7 @@ Skip the confirmation prompt only if the user explicitly said "don't stop to con
 
 ### Phase 2 — Implement
 
-Set up isolation: either use the `Agent` tool with `isolation: "worktree"` or invoke the `superpowers:using-git-worktrees` skill to create one manually before dispatch. Main branch never gets touched directly.
+Set up isolation: either use the `Agent` tool with `isolation: "worktree"` (the tool creates and cleans up a temporary worktree automatically), or create one manually via `git worktree add` when you need multiple parallel agents to share the same branch. Full manual-setup procedure: `~/.claude/skills/my-skills/autopilot/references/implement-phase.md`. Main branch never gets touched directly.
 
 Dispatch an **implementation agent** (`subagent_type: general-purpose`) with:
 - The approved plan (verbatim)
@@ -73,7 +74,7 @@ Full briefing rules and parallelization heuristics: `~/.claude/skills/my-skills/
 
 ### Phase 3 — AI review (with bounded fix loop)
 
-Dispatch a **review agent** (`subagent_type: pr-review-toolkit:code-reviewer` if available, else `feature-dev:code-reviewer`, else `general-purpose`). Brief it with:
+Dispatch a **review agent** (`subagent_type: general-purpose`). Brief it with:
 - The original feature ask
 - The plan
 - The diff against the base branch
@@ -92,7 +93,7 @@ Full briefing rules and the severity scale: `~/.claude/skills/my-skills/autopilo
 
 1. **Orchestrator-first.** You coordinate; agents execute. Don't read files or write code yourself during phases 2–3 unless an agent explicitly failed — delegation keeps the main context clean.
 2. **Fresh context per phase.** Each phase agent gets only the inputs it needs. Don't forward the previous agent's full transcript — forward its summary plus the plan/ask.
-3. **Worktree isolation on implementation.** Never implement against the main working tree. Use `isolation: "worktree"` on the implementation agent or set up a worktree first via the `superpowers:using-git-worktrees` skill.
+3. **Worktree isolation on implementation.** Never implement against the main working tree. Use `isolation: "worktree"` on the implementation agent, or create one manually with `git worktree add <path> -b autopilot/<slug>` before dispatching (see `~/.claude/skills/my-skills/autopilot/references/implement-phase.md` for the full safety procedure).
 4. **One confirmation gate.** After Phase 1. Not before or after other phases. The whole point of the skill is autonomy — gating at every step defeats it.
 5. **Bounded fix loop.** At most 2 fix rounds before surfacing to the user. Infinite iteration hides real problems.
 6. **Parallel only when independent.** If workstreams share files or depend on each other's types/APIs, run them sequentially. Spurious parallelism produces merge conflicts and context drift.

--- a/autopilot/references/implement-phase.md
+++ b/autopilot/references/implement-phase.md
@@ -1,0 +1,89 @@
+# Implement phase — briefing contract
+
+The implementation agent(s) turn the approved plan into a committed diff on an isolated branch. They run tests. They do **not** open PRs.
+
+## Isolation
+
+Pick one of two paths:
+
+- **Agent-level isolation** — dispatch with `isolation: "worktree"`. The tool creates a temporary worktree for the agent and cleans it up if no changes were made, otherwise returns the worktree path and branch in the result. Preferred when the implementation fits in one agent call.
+- **Skill-level isolation** — invoke the `superpowers:using-git-worktrees` skill first to create a worktree the orchestrator controls. Preferred when dispatching multiple parallel implementation agents that must land on the same branch.
+
+Never dispatch an implementation agent against the main working tree.
+
+## Branch naming
+
+`autopilot/<short-slug>` where the slug is a 3–6-word summary of the feature
+(kebab-case, no trailing slashes). Examples: `autopilot/add-csv-export`,
+`autopilot/fix-oauth-refresh-race`.
+
+## Single-stream dispatch
+
+When the plan says "all sequential", dispatch one agent with the full plan.
+
+```
+You are implementing this feature on branch <branch> in worktree <path>.
+
+Feature ask (verbatim from the user):
+<ask>
+
+Approved plan:
+<plan text, verbatim>
+
+Scope hints from the user (honor verbatim, don't relitigate):
+<hints or "none">
+
+Rules:
+- Implement exactly what the plan says. No bonus refactors, no unsolicited
+  dependency bumps, no "while I'm here" changes.
+- Follow the test strategy in the plan. Add tests as the plan specifies.
+- Run the project's test command before declaring done. If tests fail,
+  investigate and fix — don't paper over failures with skips.
+- Commit in logical chunks with descriptive messages. One commit per
+  conceptual unit beats a single "implement feature" commit.
+- Match existing code conventions. Read 2-3 neighbor files before
+  introducing patterns.
+- If you hit a blocker the plan didn't anticipate, stop, commit what works,
+  and return a summary explaining the blocker and what you need.
+
+Report back with:
+- List of commits you made (one line each, with the hash)
+- Files changed (grouped: new / modified / deleted)
+- Tests added or modified, and the test command output (pass/fail)
+- Any deviation from the plan, with reason
+- Any blocker that prevented you from finishing
+
+Keep the final report under 300 words. Detail belongs in commit messages.
+```
+
+## Parallel dispatch
+
+When the plan lists independent workstreams:
+
+- **Independence check** — two workstreams are independent only if they don't
+  share files AND don't depend on each other's types / APIs. If one defines
+  a type the other consumes, they're sequential.
+- **Single message, multiple `Agent` calls** — parallel dispatch means one
+  orchestrator turn with N `Agent` tool uses. Anything else is sequential.
+- **Shared context per agent** — each parallel agent gets: the verbatim ask,
+  the full plan (not just its slice — it needs to understand the whole
+  feature), its assigned slice, and a list of the other workstreams running
+  in parallel so it knows what **not** to touch.
+- **Same branch, same worktree** — all parallel agents write to the same
+  worktree. Git handles interleaved commits fine; just give each agent a
+  distinct commit message prefix (`[stream-A]`, `[stream-B]`) so the
+  reviewer can trace work later.
+
+If two supposedly-independent agents both edit the same file, that's a plan
+bug — surface it to the user after the phase and consider whether to re-plan.
+
+## What the orchestrator does after the phase
+
+1. Read each implementation agent's summary.
+2. If any reported a blocker: decide — dispatch follow-up with resolved
+   scope, ask the user, or stop.
+3. If tests failed in any summary: count that toward the review phase's
+   fix-loop budget before proceeding, or dispatch a targeted fix agent now.
+4. If all agents reported success: advance to Phase 3 (review). Don't verify
+   by reading the diff yourself — that's the reviewer's job with fresh
+   context.

--- a/autopilot/references/implement-phase.md
+++ b/autopilot/references/implement-phase.md
@@ -4,12 +4,81 @@ The implementation agent(s) turn the approved plan into a committed diff on an i
 
 ## Isolation
 
-Pick one of two paths:
+Never dispatch an implementation agent against the main working tree. Pick
+one of two paths:
 
-- **Agent-level isolation** — dispatch with `isolation: "worktree"`. The tool creates a temporary worktree for the agent and cleans it up if no changes were made, otherwise returns the worktree path and branch in the result. Preferred when the implementation fits in one agent call.
-- **Skill-level isolation** — invoke the `superpowers:using-git-worktrees` skill first to create a worktree the orchestrator controls. Preferred when dispatching multiple parallel implementation agents that must land on the same branch.
+### Path A — Agent-level isolation (single-agent implementation)
 
-Never dispatch an implementation agent against the main working tree.
+Dispatch with `isolation: "worktree"`. The `Agent` tool creates a temporary
+worktree for the agent and cleans it up if no changes were made, otherwise
+returns the worktree path and branch in the result. Preferred when the plan
+says "all sequential" and the implementation fits in one agent call.
+
+### Path B — Orchestrator-managed worktree (parallel agents on shared branch)
+
+Preferred when the plan lists independent workstreams and you'll dispatch
+multiple implementation agents that must land on the same branch.
+
+**Directory selection — priority order:**
+
+1. `.worktrees/` if it already exists at the repo root (preferred — hidden)
+2. `worktrees/` if it exists (fallback — visible)
+3. A `worktree.*director` preference in the project's `CLAUDE.md` (grep for
+   it before creating anything)
+4. Default to creating `.worktrees/` yourself
+
+**Safety — verify the directory is git-ignored before creating the worktree:**
+
+```bash
+git check-ignore -q .worktrees 2>/dev/null || echo "NOT IGNORED"
+```
+
+If `.worktrees/` isn't ignored, fix it before proceeding — otherwise the
+worktree contents pollute `git status` and can get accidentally committed:
+
+```bash
+echo '.worktrees/' >> .gitignore
+git add .gitignore && git commit -m "chore: ignore .worktrees/"
+```
+
+**Create the worktree on a new branch:**
+
+```bash
+SLUG="<short-slug>"            # e.g. add-csv-export
+BRANCH="autopilot/$SLUG"
+WORKTREE_PATH=".worktrees/$SLUG"
+git worktree add "$WORKTREE_PATH" -b "$BRANCH"
+```
+
+**Install project dependencies inside the worktree** (auto-detect):
+
+```bash
+cd "$WORKTREE_PATH"
+[ -f package.json ]    && (command -v pnpm >/dev/null && pnpm install) \
+                            || (command -v npm  >/dev/null && npm install)
+[ -f pyproject.toml ]  && (command -v poetry >/dev/null && poetry install) \
+                            || (command -v uv >/dev/null && uv sync) \
+                            || (command -v pip >/dev/null && pip install -e .)
+[ -f requirements.txt ] && command -v pip >/dev/null && pip install -r requirements.txt
+[ -f Cargo.toml ]      && command -v cargo >/dev/null && cargo build
+[ -f go.mod ]          && command -v go    >/dev/null && go mod download
+```
+
+**Baseline test run** — optional but recommended. If the project has a test
+command (check `package.json` scripts, `Makefile`, `pyproject.toml`), run it
+once inside the worktree and record the result. This lets the review phase
+distinguish new test failures from pre-existing ones.
+
+**Hand the path to each dispatched agent** — every parallel agent gets
+`cwd: $WORKTREE_PATH` in its briefing so they all work against the same
+worktree on the same branch.
+
+**Cleanup after the full pipeline** — after the user accepts the handoff
+(or rejects and wants to discard), run:
+
+```bash
+git worktree remove "$WORKTREE_PATH"   # or --force if uncommitted state
+```
 
 ## Branch naming
 

--- a/autopilot/references/plan-phase.md
+++ b/autopilot/references/plan-phase.md
@@ -1,0 +1,74 @@
+# Plan phase — briefing contract
+
+The planning agent's job is to turn a feature ask into a concrete, reviewable plan. It does **not** implement.
+
+## Agent dispatch
+
+Prefer `subagent_type: Plan` — it's a specialized software-architect agent. Fall back to `general-purpose` only if Plan isn't available in the environment.
+
+Run it with `run_in_background: false` — you need the plan back before Phase 2 can start.
+
+## Briefing template
+
+The agent starts with no knowledge of this conversation. Include all of:
+
+```
+You are planning implementation for this feature ask:
+
+<verbatim feature ask from the user>
+
+Context you should gather before planning:
+- Repo root: <path>
+- Base branch: <branch>
+- Any existing spec / issue / linked doc: <paths or URLs>
+- Scope hints from the user: <verbatim hints, or "none">
+
+Produce a plan covering:
+
+1. Problem statement — 1 to 3 sentences. What are we building and why.
+2. Files to create / modify — bullet list, one line of purpose each.
+   Group by directory. Flag new files vs. existing.
+3. Public API / interface changes — types, function signatures, route shapes,
+   schema changes. "None" is a valid answer.
+4. Test strategy — what tests to add, what tests to modify, how to run them
+   locally. Check the repo for the existing test command (package.json scripts,
+   Makefile, CI config) — don't invent one.
+5. Parallelizable workstreams — if parts of the implementation are independent
+   (no shared files, no type dependencies on each other), list them. If
+   everything must be sequential, say "all sequential" explicitly.
+6. Risks / unknowns — things you're unsure about or flags for the reviewer.
+   Be specific. "The existing X pattern is unclear, picking Y on the assumption
+   that Z" beats "maybe some risk".
+
+Rules:
+- Do not write any code. The plan is text only.
+- Do not ask clarifying questions — make your best inference and flag it under
+  risks instead.
+- Keep the plan under ~800 words. Concrete beats exhaustive.
+- Match existing project conventions — read 2-3 neighbor files before
+  prescribing a pattern.
+
+Report the plan back as your final message.
+```
+
+## What the orchestrator does with the plan
+
+1. Print it verbatim to the user.
+2. Ask: "Ship as-is, or changes?"
+3. If changes: re-dispatch the planning agent, briefing it with the original
+   ask **plus** the user's feedback. Don't paraphrase the feedback — include
+   the user's exact wording.
+4. If approved: store the plan text for Phase 2's implementation agent. It
+   will be forwarded verbatim.
+
+## Common mistakes the orchestrator should catch
+
+- Plan is just a restatement of the ask — no file list, no API changes, no
+  test strategy. Reject, re-dispatch with "list the specific files you'll
+  touch and the test strategy".
+- Plan assumes a testing framework that isn't in the repo. Reject with "read
+  package.json / the CI config first and use the actual test command".
+- Plan has "TBD" or "depends on" in critical sections. Reject with "resolve
+  these — if you can't, list them as risks with your chosen assumption".
+- Plan suggests unrelated refactoring bundled with the feature. Reject with
+  "minimal changes only — remove anything the feature ask didn't require".

--- a/autopilot/references/review-phase.md
+++ b/autopilot/references/review-phase.md
@@ -1,0 +1,121 @@
+# Review phase — briefing contract
+
+The review agent evaluates the diff against the ask + plan, with fresh context, and produces categorized findings. The fix agent then resolves blocking/should-fix findings. Cap iteration at 2 rounds.
+
+## Agent dispatch — review
+
+Prefer in this order:
+1. `pr-review-toolkit:code-reviewer`
+2. `feature-dev:code-reviewer`
+3. `superpowers:code-reviewer`
+4. `general-purpose`
+
+Use the first that's available in the environment. Each will behave slightly differently; that's fine — the briefing template below works for any of them.
+
+## Briefing template — review
+
+```
+You are reviewing a feature implementation. You have not seen the plan or the
+implementation session — review with fresh eyes.
+
+Feature ask (from the user):
+<ask>
+
+Plan that was approved and followed:
+<plan text>
+
+Branch under review: <branch>
+Base branch: <base>
+
+Inspection approach:
+- Read the full diff: `git diff <base>...<branch>`
+- Read each changed file in full (not just the diff hunks). Context matters.
+- Check that tests were added per the plan's test strategy and that they run
+  (re-run the test command yourself).
+
+Find issues in these categories, ranked by severity:
+
+- BLOCKING — bugs, logic errors, security issues, data-loss risks, broken
+  tests, or changes that violate the plan's intent. Anything that should
+  stop this from merging.
+- SHOULD-FIX — missing edge-case handling, test gaps, unclear code,
+  unnecessary scope creep beyond the plan, naming issues that will confuse
+  readers.
+- NIT — stylistic nits, minor doc gaps, things a maintainer might care
+  about but that don't affect correctness.
+
+For each finding, include:
+- Severity (BLOCKING / SHOULD-FIX / NIT)
+- File path and line number(s)
+- What's wrong in one sentence
+- Concrete remediation (not "consider refactoring" — say what to change)
+
+If you find zero BLOCKING and zero SHOULD-FIX issues, say so explicitly.
+
+Do not make changes. Do not run the implementation agent's decisions through
+a second-guessing pass — evaluate them against the plan and the ask, not
+against what you would have done.
+
+Report back as a structured list, grouped by severity.
+```
+
+## Decision tree after review
+
+The orchestrator reads the findings and picks one of:
+
+- **Zero BLOCKING + zero SHOULD-FIX findings** — pipeline done. Return the
+  review text in the final handoff. NIT findings are included but not
+  actioned.
+- **Any BLOCKING or SHOULD-FIX, iteration count < 2** — dispatch a fix agent
+  (below), then re-run the review agent on the updated diff. Increment the
+  counter.
+- **Iteration count = 2 and findings remain** — stop. Hand off to the user
+  with the remaining findings and a note that the pipeline hit the 2-round
+  cap. Do not start a third round without explicit user approval.
+
+## Agent dispatch — fix
+
+Use `general-purpose` for the fix agent. It needs to read the review findings,
+the existing code, and make targeted changes.
+
+## Briefing template — fix
+
+```
+A code review surfaced issues on branch <branch> (base: <base>). Fix the
+BLOCKING and SHOULD-FIX findings below. Leave NITs alone unless they're
+trivial to fix in passing.
+
+Review findings:
+<verbatim review output>
+
+Rules:
+- Make the minimum change that resolves each finding. Don't refactor nearby
+  code that wasn't flagged.
+- Preserve the commit history style from the implementation phase — new
+  commits in logical units, one per finding or per cluster of related fixes.
+- Re-run the project's test command before declaring done. If the fixes
+  broke other tests, fix those too.
+- If a finding is wrong (the reviewer misunderstood), push back: explain in
+  your summary why you didn't change anything, rather than making a
+  pointless edit.
+
+Report back with:
+- One-line summary per finding: what you did (or why you didn't)
+- New commit hashes
+- Test command output after fixes
+
+Keep the report under 250 words.
+```
+
+## Post-fix flow
+
+After the fix agent returns:
+1. Read its summary.
+2. Re-dispatch the review agent on the updated diff — same briefing, explicitly
+   noting "this is round N of review after fixes".
+3. Apply the decision tree again.
+
+## Counter hygiene
+
+Track iteration count in the orchestrator's working memory. Reset per
+autopilot run; don't carry counts across runs.

--- a/autopilot/references/review-phase.md
+++ b/autopilot/references/review-phase.md
@@ -4,13 +4,14 @@ The review agent evaluates the diff against the ask + plan, with fresh context, 
 
 ## Agent dispatch — review
 
-Prefer in this order:
-1. `pr-review-toolkit:code-reviewer`
-2. `feature-dev:code-reviewer`
-3. `superpowers:code-reviewer`
-4. `general-purpose`
+Use `subagent_type: general-purpose`. Always available, and the briefing
+template below does the heavy lifting — specialized reviewer plugins aren't
+required.
 
-Use the first that's available in the environment. Each will behave slightly differently; that's fine — the briefing template below works for any of them.
+If you know a more specialized reviewer plugin is installed in this
+environment (e.g. one that focuses on PR-scale diffs or security), you may
+substitute it, but don't assume it exists. The skill is self-sufficient with
+`general-purpose`.
 
 ## Briefing template — review
 


### PR DESCRIPTION
## Summary

Adds a new skill, `/autopilot`, that drives a three-phase autonomous feature build inside a single Claude Code conversation. Each phase runs as a fresh-context subagent so the orchestrator session stays at the coordination layer.

- **Plan** — Plan/general-purpose agent produces a concrete plan (files, API changes, test strategy, parallelizable workstreams, risks). User confirmation gate lives here.
- **Implement** — `general-purpose` agent(s) in an isolated git worktree execute the plan and run tests. Parallel dispatch is used when the plan lists independent workstreams (no shared files / no type dependencies).
- **AI review** — `general-purpose` reviewer returns findings categorized as `BLOCKING` / `SHOULD-FIX` / `NIT`. A bounded **2-round fix loop** addresses blocking and should-fix findings before handing off.

Per-phase briefing contracts live in `autopilot/references/{plan,implement,review}-phase.md` and are addressed from `SKILL.md` via absolute paths, per this repo's gstack convention.

## Self-sufficient — no external-plugin dependencies

Second commit (`ff035e9`) makes the skill work in any Claude Code environment. Every reference to `superpowers:*`, `pr-review-toolkit:*`, and `feature-dev:code-reviewer` was removed; the useful techniques from those skills (especially the worktree setup procedure) are now documented inline:

- **Worktree setup** (in `implement-phase.md`) — directory priority (`.worktrees/` > `worktrees/` > `CLAUDE.md` preference > default), `git check-ignore` safety verification, auto-detected dependency install (pnpm/npm, poetry/uv/pip, cargo, go mod), optional baseline test run, explicit `git worktree remove` cleanup.
- **Review phase** — always dispatches `subagent_type: general-purpose` with a full structured briefing. Quality comes from the briefing template, not from a specialized reviewer plugin.

Verify with: `grep -rn -E "(superpowers:|pr-review-toolkit:|feature-dev:code-reviewer)" autopilot/` → no matches.

## Pattern attribution

Pipeline pattern ported from [AndyMik90/Aperant](https://github.com/AndyMik90/Aperant) (an Electron-based autonomous coding framework). Aperant's full pipeline is `spec → planner → coder → QA reviewer → QA fixer`; this skill is the single-Claude-Code-conversation adaptation using the `Agent` tool for phase dispatch and `isolation: "worktree"` (or manual `git worktree add`) for branch isolation.

## Design decisions

- **Single user confirmation gate** after Phase 1 — not every step, since the point is autonomy.
- **Worktree isolation mandatory** on the implementation phase — never touches the main working tree.
- **Fix loop is bounded** at 2 rounds — infinite iteration hides real problems.
- **No PR opened by the skill** — handoff is the branch. Compose with `/ship` (gstack) or manual `gh pr create`.
- **`general-purpose` everywhere** — only agent type guaranteed to exist in every environment. Briefing templates carry the specialization.

## Test plan

- [x] `./setup` discovers `autopilot/`, creates `~/.claude/skills/autopilot/` with `SKILL.md` symlink (real-dir pattern from #3)
- [x] `./setup --uninstall` removes the autopilot directory cleanly
- [x] Frontmatter `name: autopilot` is picked up by the generated CLAUDE.md block (`/autopilot` appears in the list)
- [x] All sibling references (`references/*.md`) use absolute paths — no relative-path regressions
- [x] No external-plugin dependencies remain in the skill tree
- [ ] End-to-end dry run against a small feature ask in a throwaway repo

## Files added

| Path | Purpose |
|---|---|
| `autopilot/SKILL.md` | Skill entry point — pipeline overview, when-to-use, operating rules |
| `autopilot/references/plan-phase.md` | Briefing contract + reject rules for the planning agent |
| `autopilot/references/implement-phase.md` | Isolation strategy (agent-level and inline worktree procedure), single vs. parallel dispatch templates |
| `autopilot/references/review-phase.md` | Severity scale, fix-loop decision tree, review + fix briefings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)